### PR TITLE
feat: add Ctrl + A arrange shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,18 @@
-Node Arrange
-=======
+# Node Arrange
 
 An add-on for the automatic layout of nodes.
 
 No matter the node tree complexity, nodes will be pleasingly arranged, organised, and aligned. Adjust the settings to suit your taste.
 
-Install
----
+## Install
 
 Download from the [Blender Extensions Platform](https://extensions.blender.org/add-ons/node-arrange/).
 
-Location
----
+## Location
 
 Node Editor ‣ Sidebar ‣ Arrange
+
+## Shortcuts
+
+- <kbd>Ctrl</kbd> + <kbd>A</kbd> — Batch arrange nodes
+- <kbd>Alt</kbd> + <kbd>G</kbd> — Arrange selected nodes

--- a/source/keymaps.py
+++ b/source/keymaps.py
@@ -10,6 +10,7 @@ def register() -> None:
     if kc := bpy.context.window_manager.keyconfigs.addon:
         km = kc.keymaps.new(name='Node Editor', space_type="NODE_EDITOR")
         kmi = km.keymap_items.new("node.na_recenter_selected", type='G', value='PRESS', alt=True)
+        kmi = km.keymap_items.new("node.na_arrange_selected", type='A', value='PRESS', ctrl=True)
         addon_keymaps.append((km, kmi))
 
 


### PR DESCRIPTION
First of all big thanks for this extension. 

As someone who continuously likes to keep my nodes organized, I want to be able to arrange all nodes with a shortcut. I think it could be implemented as such, though I have no blender extension development experience. Maybe it can serve as inspiration. Ideas for better shortcuts would also be appreciated, because I think <kbd>Ctrl</kbd> + <kbd>A</kbd> might not be the best.